### PR TITLE
Make profile_tasks variable thread local to prevent race condition.

### DIFF
--- a/src/nanothread.cpp
+++ b/src/nanothread.cpp
@@ -198,7 +198,11 @@ void pool_set_size(Pool *pool, uint32_t size) {
     }
 }
 
-int profile_tasks = false;
+#if defined(_MSC_VER)
+  __declspec(thread) int profile_tasks = false;
+#else
+  __thread int profile_tasks = false;
+#endif
 
 int pool_profile() {
     return (int) profile_tasks;

--- a/src/queue.h
+++ b/src/queue.h
@@ -246,7 +246,11 @@ private:
 
 extern "C" uint32_t pool_thread_id();
 
-extern int profile_tasks;
+#if defined(_MSC_VER)
+  extern __declspec(thread) int profile_tasks;
+#else
+  extern __thread int profile_tasks;
+#endif
 
 #define DJT_STR_2(x) #x
 #define DJT_STR(x)   DJT_STR_2(x)


### PR DESCRIPTION
The `profile_tasks`variable is currently not thread local. This is in conflict with its use in drjit-core: There it is set within `jitc_set_flags`, which can be called from multiple threads. All the drjit-core flags are therefore thread local. This commit makes the `profile_tasks` variable thread local to be consistent with the way flags are handled in drjit-core. 
