### PR TITLE
cmake: make pre-built library discoverable via CMake configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.clangd
 /compile_commands.json
 *.cmake
+!nanothreadConfig.cmake
 CMakeCache.txt
 CMakeFiles
 Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ target_compile_definitions(nanothread PRIVATE -DNANOTHREAD_BUILD=1)
 set_target_properties(nanothread PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 
 if (NANOTHREAD_ENABLE_TESTS)
-   add_subdirectory(tests)
+  include(CTest)
+  add_subdirectory(tests)
 endif()
 
 configure_file(nanothreadConfig.cmake "${CMAKE_CURRENT_BINARY_DIR}/nanothread/nanothreadConfig.cmake" COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,3 +73,33 @@ set_target_properties(nanothread PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE
 if (NANOTHREAD_ENABLE_TESTS)
    add_subdirectory(tests)
 endif()
+
+configure_file(nanothreadConfig.cmake "${CMAKE_CURRENT_BINARY_DIR}/nanothread/nanothreadConfig.cmake" COPYONLY)
+install(
+  FILES
+    nanothreadConfig.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/nanothread
+)
+install(
+  TARGETS
+    nanothread
+  EXPORT
+    nanothreadTargets
+  INCLUDES DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  DIRECTORY
+    include/nanothread
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  EXPORT
+    nanothreadTargets
+  FILE
+    nanothreadTargets.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/nanothread
+)

--- a/include/nanothread/nanothread.h
+++ b/include/nanothread/nanothread.h
@@ -13,6 +13,10 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#if !defined(__cplusplus)
+    #include <stdbool.h>
+#endif
+
 #if defined(_MSC_VER)
 #  if defined(NANOTHREAD_BUILD)
 #    define NANOTHREAD_EXPORT    __declspec(dllexport)

--- a/nanothreadConfig.cmake
+++ b/nanothreadConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/nanothreadTargets.cmake")

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -415,9 +415,11 @@ double time_milliseconds() {
 }
 #endif
 
-std::pair<Task *, uint32_t> TaskQueue::pop_or_sleep(bool (*stopping_criterion)(void *), void *payload) {
-    std::pair<Task *, uint32_t> result(nullptr, 0);
-    uint32_t attempts = 0;
+std::pair<Task *, uint32_t>
+TaskQueue::pop_or_sleep(bool (*stopping_criterion)(void *), void *payload,
+                        bool may_sleep) {
+        std::pair<Task *, uint32_t> result(nullptr, 0);
+        uint32_t attempts = 0;
 
 #if defined(NT_DEBUG)
     double start = time_milliseconds();
@@ -431,7 +433,7 @@ std::pair<Task *, uint32_t> TaskQueue::pop_or_sleep(bool (*stopping_criterion)(v
 
         attempts++;
 
-        if (attempts >= NANOTHREAD_MAX_ATTEMPTS) {
+        if (may_sleep && attempts >= NANOTHREAD_MAX_ATTEMPTS) {
             std::unique_lock<std::mutex> guard(sleep_mutex);
 
             uint64_t value = ++sleep_state, phase = value & high_mask;

--- a/src/queue.h
+++ b/src/queue.h
@@ -212,13 +212,15 @@ public:
      * \breif Fetch a task from the queue, or sleep
      *
      * This function repeatedly tries to fetch work from the queue and sleeps
-     * if no work is available for an extended amount of time (~50 ms).
+     * if no work is available for an extended amount of time (~50 ms) and
+     * the \c may_sleep parameter is set to \c true.
      *
      * The function stops trying to acquire work and returns <tt>(nullptr,
      * 0)</tt> when the supplied function <tt>stopping_criterion(payload)</tt>
      * evaluates to true.
      */
-    std::pair<Task *, uint32_t> pop_or_sleep(bool (*stopping_criterion)(void *), void *payload);
+    std::pair<Task *, uint32_t> pop_or_sleep(bool (*stopping_criterion)(void *),
+                                             void *payload, bool may_sleep);
 
     /// Wake sleeping threads
     void wakeup();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,18 @@
 add_executable(test_01 test_01.c)
 target_link_libraries(test_01 PRIVATE nanothread)
+add_test(NAME test_01 COMMAND test_01)
 
 add_executable(test_02 test_02.cpp)
 target_link_libraries(test_02 PRIVATE nanothread)
 target_compile_features(test_02 PRIVATE cxx_std_11)
+add_test(NAME test_02 COMMAND test_02)
 
 add_executable(test_03 test_03.cpp)
 target_link_libraries(test_03 PRIVATE nanothread)
 target_compile_features(test_03 PRIVATE cxx_std_14)
+add_test(NAME test_03 COMMAND test_03)
 
 add_executable(test_04 test_04.cpp)
 target_link_libraries(test_04 PRIVATE nanothread)
 target_compile_features(test_04 PRIVATE cxx_std_11)
+add_test(NAME test_04 COMMAND test_04)


### PR DESCRIPTION
Initial work, started by @SomeoneSerge to add Mitsuba 3 to Nixpkgs: https://github.com/NixOS/nixpkgs/pull/269378

This PR adds the ability to make `nanothread` discoverable via CMake instead of requiring projects vendor it in-tree.

Additionally, it allows testing through CMake by using CTests